### PR TITLE
Add test coverage for tidal and river IO

### DIFF
--- a/mhkit/tests/test_river.py
+++ b/mhkit/tests/test_river.py
@@ -239,7 +239,7 @@ class TestIO(unittest.TestCase):
         self.assertEqual(data.shape, (31, 1))
 
 
-    def test_request_usgs_data(self):
+    def test_request_usgs_data_daily(self):
         data=river.io.request_usgs_data(station="15515500",
                             parameter='00060',
                             start_date='2009-08-01',
@@ -247,8 +247,18 @@ class TestIO(unittest.TestCase):
                             data_type='Daily')
         self.assertEqual(data.columns, ['Discharge, cubic feet per second'])
         self.assertEqual(data.shape, (10, 1))
- 
-#        import ipdb; ipdb.set_trace() 
+    
+   
+    def test_request_usgs_data_instant(self):
+        data=river.io.request_usgs_data(station="15515500",
+                            parameter='00060',
+                            start_date='2009-08-01',
+                            end_date='2009-08-10',
+                            data_type='Instantaneous')
+        self.assertEqual(data.columns, ['Discharge, cubic feet per second'])
+        # Every 15 minutes or 4 times per hour
+        self.assertEqual(data.shape, (10*24*4, 1))
+
 
 if __name__ == '__main__':
     unittest.main() 

--- a/mhkit/tests/test_river.py
+++ b/mhkit/tests/test_river.py
@@ -238,6 +238,18 @@ class TestIO(unittest.TestCase):
         self.assertEqual((data.index == expected_index.tz_localize('UTC')).all(), True)
         self.assertEqual(data.shape, (31, 1))
 
+
+    def test_request_usgs_data(self):
+        data=river.io.request_usgs_data(station="15515500",
+                            parameter='00060',
+                            start_date='2009-08-01',
+                            end_date='2009-08-10',
+                            data_type='Daily')
+        self.assertEqual(data.columns, ['Discharge, cubic feet per second'])
+        self.assertEqual(data.shape, (10, 1))
+ 
+#        import ipdb; ipdb.set_trace() 
+
 if __name__ == '__main__':
     unittest.main() 
 

--- a/mhkit/tests/test_tidal.py
+++ b/mhkit/tests/test_tidal.py
@@ -25,6 +25,13 @@ class TestIO(unittest.TestCase):
         data, metadata = tidal.io.read_noaa_json(file_name)
         self.assertTrue(np.all(data.columns == ['s','d','b']) )
         self.assertEqual(data.shape, (18890, 3))
+
+    def test_request_noaa_data(self):
+        data, metadata = tidal.io.request_noaa_data(station='s08010', parameter='currents',
+                                       start_date='20180101', end_date='20180102',
+                                       proxy=None, write_json=None)
+        self.assertTrue(np.all(data.columns == ['s','d','b']) )
+        self.assertEqual(data.shape, (92, 3))
         
 
 class TestResource(unittest.TestCase):
@@ -50,7 +57,6 @@ class TestResource(unittest.TestCase):
     def test_principal_flow_directions(self):    
         width_direction=10
         direction1, direction2 = tidal.resource.principal_flow_directions(self.data.d, width_direction)
-
         self.assertEqual(direction1,172.0) 
         self.assertEqual(round(direction2,1),round(352.3,1))                                                                                   
     


### PR DESCRIPTION
Added 3 tests:
1. river.io.request)usgs_data('Dailiy')
2. river.io.request)usgs_data('Instant')
3. tidial.io.request_noaa_data()

Note: Test 3 above calls on tidal.io._xml_to_dataframe 