### PR TITLE
wave.resource.surface_elevation: add missing sqrt in  and unit test

### DIFF
--- a/mhkit/tests/test_wave.py
+++ b/mhkit/tests/test_wave.py
@@ -70,7 +70,7 @@ class TestResourceSpectrum(unittest.TestCase):
         S = wave.resource.jonswap_spectrum(self.f, self.Tp, self.Hs)
         eta = wave.resource.surface_elevation(S, self.t)
         dt = self.t[1] - self.t[0]
-        Sn = wave.resource.elevation_spectrum(eta, 1/dt, len(eta.values), 
+        Sn = wave.resource.elevation_spectrum(eta, 1/dt, len(eta), 
                                               detrend=False, window='boxcar',
                                               noverlap=0)
 

--- a/mhkit/tests/test_wave.py
+++ b/mhkit/tests/test_wave.py
@@ -18,7 +18,9 @@ class TestResourceSpectrum(unittest.TestCase):
         self.f = omega/(2*np.pi)
         self.Hs = 2.5
         self.Tp = 8
-        self.t = np.arange(0, 60*10, 0.05)
+        df = self.f[1] - self.f[0]
+        Trep = 1/df
+        self.t = np.arange(0, Trep, 0.05)
             
     @classmethod
     def tearDownClass(self):
@@ -43,21 +45,22 @@ class TestResourceSpectrum(unittest.TestCase):
         self.assertLess(errorHm0, 0.01)
         self.assertLess(errorTp0, 0.01)
 
-    def test_surface_elevation(self):
+    def test_surface_elevation_moments(self):
         S = wave.resource.jonswap_spectrum(self.f, self.Tp, self.Hs)
         eta = wave.resource.surface_elevation(S, self.t)
         dt = self.t[1] - self.t[0]
-        df = self.f[1] - self.f[0]
-        Sn = wave.resource.elevation_spectrum(eta, 1/dt, int(np.floor(self.t[-1]/df)))
+        Sn = wave.resource.elevation_spectrum(eta, 1/dt, len(eta.values), 
+                                              detrend=False, window='boxcar',
+                                              noverlap=0)
 
         m0 = wave.resource.frequency_moment(S,0).m0.values[0]
-        m0n = wave.resource.frequency_moment(S,0).m0.values[0]
+        m0n = wave.resource.frequency_moment(Sn,0).m0.values[0]
         errorm0 = np.abs((m0 - m0n)/m0)
 
         self.assertLess(errorm0, 0.01)
 
         m1 = wave.resource.frequency_moment(S,1).m1.values[0]
-        m1n = wave.resource.frequency_moment(S,1).m1.values[0]
+        m1n = wave.resource.frequency_moment(Sn,1).m1.values[0]
         errorm1 = np.abs((m1 - m1n)/m1)
 
         self.assertLess(errorm1, 0.01)

--- a/mhkit/tests/test_wave.py
+++ b/mhkit/tests/test_wave.py
@@ -18,6 +18,7 @@ class TestResourceSpectrum(unittest.TestCase):
         self.f = omega/(2*np.pi)
         self.Hs = 2.5
         self.Tp = 8
+        self.t = np.arange(0, 60*10, 0.05)
             
     @classmethod
     def tearDownClass(self):
@@ -41,6 +42,25 @@ class TestResourceSpectrum(unittest.TestCase):
         
         self.assertLess(errorHm0, 0.01)
         self.assertLess(errorTp0, 0.01)
+
+    def test_surface_elevation(self):
+        S = wave.resource.jonswap_spectrum(self.f, self.Tp, self.Hs)
+        eta = wave.resource.surface_elevation(S, self.t)
+        dt = self.t[1] - self.t[0]
+        df = self.f[1] - self.f[0]
+        Sn = wave.resource.elevation_spectrum(eta, 1/dt, int(np.floor(self.t[-1]/df)))
+
+        m0 = wave.resource.frequency_moment(S,0).m0.values[0]
+        m0n = wave.resource.frequency_moment(S,0).m0.values[0]
+        errorm0 = np.abs((m0 - m0n)/m0)
+
+        self.assertLess(errorm0, 0.01)
+
+        m1 = wave.resource.frequency_moment(S,1).m1.values[0]
+        m1n = wave.resource.frequency_moment(S,1).m1.values[0]
+        errorm1 = np.abs((m1 - m1n)/m1)
+
+        self.assertLess(errorm1, 0.01)
     
     def test_jonswap_spectrum(self):
         S = wave.resource.jonswap_spectrum(self.f, self.Tp, self.Hs)

--- a/mhkit/tests/test_wave.py
+++ b/mhkit/tests/test_wave.py
@@ -76,9 +76,9 @@ class TestResourceSpectrum(unittest.TestCase):
 
         fSn = interp1d(Sn.index.values, Sn.values, axis=0)
         rmse = (S.values - fSn(S.index.values))**2
-        rmse_sum = np.sum(rmse)
+        rmse_sum = (np.sum(rmse)/len(rmse))**0.5
 
-        self.assertLess(rmse_sum, 0.1)
+        self.assertLess(rmse_sum, 0.02)
     
     def test_jonswap_spectrum(self):
         S = wave.resource.jonswap_spectrum(self.f, self.Tp, self.Hs)

--- a/mhkit/wave/resource.py
+++ b/mhkit/wave/resource.py
@@ -230,7 +230,8 @@ def surface_elevation(S, time_index, seed=123):
 
     # Wave amplitude times delta f, truncated
     A = 2*S 
-    A = A.multiply(delta_f, axis=0)    
+    A = A.multiply(delta_f, axis=0)
+    A = np.sqrt(A)
     A = A.loc[start_time:end_time,:]
     
     # Product of omega and time

--- a/mhkit/wave/resource.py
+++ b/mhkit/wave/resource.py
@@ -6,7 +6,7 @@ from itertools import product as _product
 
 
 ### Spectrum
-def elevation_spectrum(eta, sample_rate, nnft, window='hann', detrend=True):
+def elevation_spectrum(eta, sample_rate, nnft, window='hann', detrend=True, noverlap=None):
     """
     Calculates the wave energy spectrum from wave elevation time-series
     
@@ -49,7 +49,7 @@ def elevation_spectrum(eta, sample_rate, nnft, window='hann', detrend=True):
         if detrend:
             data = _signal.detrend(data.dropna(), axis=-1, type='linear', bp=0)
         [f, wave_spec_measured] = _signal.welch(data, fs=sample_rate, window=window, 
-            nperseg=nnft, nfft=nnft) 
+            nperseg=nnft, nfft=nnft, noverlap=noverlap) 
         S[col] = wave_spec_measured
     S.index=f
     S.columns = eta.columns


### PR DESCRIPTION
I believe I found a missing sqrt in the `waves.resource.surface_elevation` function (the time series of the surface elevation was too small). Fixed and added unit test. Here's the ad-hoc code I used to find the problem. 

```python
from mhkit import wave
import numpy as np
import matplotlib.pylab as plt

gamma = 9
Tp = 1/3
Hs = 5e-2

f_low = 2
f_high = 4
df = 1/30

f = np.arange(f_low, f_high, df)

S = wave.resource.jonswap_spectrum(f, Tp, Hs, gamma)
S.columns = ['orig.']
axs = S.plot(style='.-')
# plt.grid(True)

dt = 0.01
t = np.arange(0,2*60+dt,0.01)
eta = wave.resource.surface_elevation(S, t)
ax = eta.plot()
ax.set_xticks(np.arange(0,t[-1]+1/df,1/df))

Sn = wave.resource.elevation_spectrum(eta, 1/dt, int(np.floor(t[-1]/df)))
Sn.columns = ['from eta']
Sn.plot(ax=axs, style='.--', grid=True)
axs.set_xlim(f_low,f_high)

plt.grid(True)

plt.show()

```