### PR TITLE
Explicit phasing in surface_elevation (& add frequency_bins  opt)

### DIFF
--- a/mhkit/tests/test_wave.py
+++ b/mhkit/tests/test_wave.py
@@ -95,10 +95,10 @@ class TestResourceSpectrum(unittest.TestCase):
         f_bins_np = np.array([np.diff(S.index)[0]]*len(S))
         f_bins_pd = pd.DataFrame(f_bins_np, index=S.index, columns=['df'])
 
-        eta_np = wave.resource.surface_elevation(S, self.t, frequency_bins=f_bins_np)
-        #import ipdb; ipdb.set_trace()
+        eta_np = wave.resource.surface_elevation(S, self.t, frequency_bins=f_bins_np)        
         eta_pd = wave.resource.surface_elevation(S, self.t, frequency_bins=f_bins_pd)
 
+        assert_frame_equal(eta0, eta_np)        
         assert_frame_equal(eta_np, eta_pd)        
 
     def test_surface_elevation_moments(self):

--- a/mhkit/tests/test_wave.py
+++ b/mhkit/tests/test_wave.py
@@ -7,6 +7,9 @@ import json
 import matplotlib.pylab as plt
 import mhkit.wave as wave
 from scipy.interpolate import interp1d
+from pandas.testing import assert_frame_equal
+import inspect
+
 
 testdir = dirname(abspath(__file__))
 datadir = join(testdir, 'data')
@@ -46,6 +49,22 @@ class TestResourceSpectrum(unittest.TestCase):
         self.assertLess(errorHm0, 0.01)
         self.assertLess(errorTp0, 0.01)
 
+    def test_surface_elevation_phasing(self):
+        S = wave.resource.bretschneider_spectrum(self.f,self.Tp,self.Hs)
+
+        sig = inspect.signature(wave.resource.surface_elevation)
+        seednum = sig.parameters['seed'].default
+
+        eta0 = wave.resource.surface_elevation(S, self.t)
+        eta1 = wave.resource.surface_elevation(S, self.t, seed=seednum)
+
+        np.random.seed(seednum)
+        phases = np.random.rand(len(S)) * 2 * np.pi
+        eta2 = wave.resource.surface_elevation(S, self.t, phases=phases)
+
+        assert_frame_equal(eta0, eta1)
+        assert_frame_equal(eta0, eta2)
+        
     def test_surface_elevation_moments(self):
         S = wave.resource.jonswap_spectrum(self.f, self.Tp, self.Hs)
         eta = wave.resource.surface_elevation(S, self.t)

--- a/mhkit/tests/test_wave.py
+++ b/mhkit/tests/test_wave.py
@@ -64,7 +64,24 @@ class TestResourceSpectrum(unittest.TestCase):
 
         assert_frame_equal(eta0, eta1)
         assert_frame_equal(eta0, eta2)
-        
+
+    def test_surface_elevation_phases_np(self):
+        S0 = wave.resource.bretschneider_spectrum(self.f,self.Tp,self.Hs)
+        S1 = wave.resource.bretschneider_spectrum(self.f,self.Tp,self.Hs*1.1)
+        S = pd.concat([S0, S1], axis=1)
+
+        phases = np.random.rand(S.shape[0], S.shape[1]) * 2 * np.pi
+        wave.resource.surface_elevation(S, self.t, phases=phases)
+
+    def test_surface_elevation_phases_pd(self):
+        S0 = wave.resource.bretschneider_spectrum(self.f,self.Tp,self.Hs)
+        S1 = wave.resource.bretschneider_spectrum(self.f,self.Tp,self.Hs*1.1)
+        S = pd.concat([S0, S1], axis=1)
+
+        phases_pd = pd.DataFrame(np.random.rand(S.shape[0], S.shape[1]) * 2 * np.pi,
+                                 index=S.index, columns=S.columns)
+        wave.resource.surface_elevation(S, self.t, phases=phases_pd)
+
     def test_surface_elevation_moments(self):
         S = wave.resource.jonswap_spectrum(self.f, self.Tp, self.Hs)
         eta = wave.resource.surface_elevation(S, self.t)

--- a/mhkit/wave/resource.py
+++ b/mhkit/wave/resource.py
@@ -234,13 +234,17 @@ def surface_elevation(S, time_index, seed=123, frequency_bins=None,phases=None):
 
     f = pd.Series(S.index)
     f.index = f
-        
+    
     if frequency_bins is None:        
         delta_f = f.diff()
+        #delta_f[0] = f[1]-f[0]
+
     elif isinstance(frequency_bins, np.ndarray):
-        delta_f = pd.DataFrame(frequency_bins, index=S.index, columns=['df'])
+        delta_f = pd.Series(frequency_bins, index=S.index)
     elif isinstance(frequency_bins, pd.DataFrame):
-        delta_f = frequency_bins
+        assert len(frequency_bins.columns) == 1, ('frequency_bins must only'
+                'contain 1 column')        
+        delta_f = frequency_bins.squeeze()
 
     if phases is None:
         np.random.seed(seed)
@@ -315,7 +319,7 @@ def frequency_moment(S, N, frequency_bins=None):
         delta_f = pd.Series(frequency_bins)
 
     delta_f.index = f
-# import ipdb; ipdb.set_trace()    
+ 
     m = spec.multiply(fn,axis=0).multiply(delta_f,axis=0)
     m = m.sum(axis=0)
     

--- a/mhkit/wave/resource.py
+++ b/mhkit/wave/resource.py
@@ -214,7 +214,8 @@ def surface_elevation(S, time_index, seed=123, phases=None):
     assert isinstance(time_index, np.ndarray), 'time_index must be of type np.ndarray'
     assert isinstance(seed, (type(None),int)), 'seed must be of type int'
     assert isinstance(phases, (type(None),np.ndarray)), 'phases must be of type np.ndarray'
-    assert len(phases) == len(S), 'length of phases must match S'
+    if phases is not None:
+        assert len(phases) == len(S), 'length of phases must match S'
     
     
     start_time = time_index[0]

--- a/mhkit/wave/resource.py
+++ b/mhkit/wave/resource.py
@@ -183,7 +183,7 @@ def jonswap_spectrum(f, Tp, Hs, gamma=3.3):
     return S
 
 ### Metrics
-def surface_elevation(S, time_index, seed=123):
+def surface_elevation(S, time_index, seed=123, phases=None):
     """
     Calculates wave elevation time-series from spectrum using a random phase
     
@@ -196,6 +196,9 @@ def surface_elevation(S, time_index, seed=123):
         for example, time = np.arange(0,100,0.01)
     seed: int (optional)
         Random seed
+    phases: numpy array (optional)
+        Explicit phases for frequency components (overrides seed)
+        for example, phases = np.random.rand(len(S)) * 2 * np.pi
         
     Returns
     ---------
@@ -209,9 +212,10 @@ def surface_elevation(S, time_index, seed=123):
         pass
     assert isinstance(S, pd.DataFrame), 'S must be of type pd.DataFrame'
     assert isinstance(time_index, np.ndarray), 'time_index must be of type np.ndarray'
-    assert isinstance(seed, int), 'seed must be of type int'
+    assert isinstance(seed, (type(None),int)), 'seed must be of type int'
+    assert isinstance(phases, np.ndarray), 'phases must be of type np.ndarray'
+    assert len(phases) == len(S), 'length of phases must match S'
     
-    np.random.seed(seed)
     
     start_time = time_index[0]
     end_time = time_index[-1]
@@ -220,7 +224,11 @@ def surface_elevation(S, time_index, seed=123):
     f.index = f
     delta_f = f.diff()
     
-    phase = pd.Series(2*np.pi*np.random.rand(f.size))
+    if phases is None:
+        np.random.seed(seed)
+        phase = pd.Series(2*np.pi*np.random.rand(f.size))
+    else:
+        phase = pd.Series(phases)
     phase.index = f
     phase = phase[start_time:end_time] # Should phase, omega, and A*delta_f be 
                                         #   truncated before computation?

--- a/mhkit/wave/resource.py
+++ b/mhkit/wave/resource.py
@@ -185,7 +185,7 @@ def jonswap_spectrum(f, Tp, Hs, gamma=3.3):
 ### Metrics
 def surface_elevation(S, time_index, seed=123, phases=None):
     """
-    Calculates wave elevation time-series from spectrum using a random phase
+    Calculates wave elevation time-series from spectrum
     
     Parameters
     ------------    
@@ -196,7 +196,7 @@ def surface_elevation(S, time_index, seed=123, phases=None):
         for example, time = np.arange(0,100,0.01)
     seed: int (optional)
         Random seed
-    phases: numpy array (optional)
+    phases: numpy array or pandas DataFrame (optional)
         Explicit phases for frequency components (overrides seed)
         for example, phases = np.random.rand(len(S)) * 2 * np.pi
         

--- a/mhkit/wave/resource.py
+++ b/mhkit/wave/resource.py
@@ -5,6 +5,7 @@ from scipy import signal as _signal
 from itertools import product as _product
 
 
+
 ### Spectrum
 def elevation_spectrum(eta, sample_rate, nnft, window='hann', detrend=True, noverlap=None):
     """
@@ -183,7 +184,7 @@ def jonswap_spectrum(f, Tp, Hs, gamma=3.3):
     return S
 
 ### Metrics
-def surface_elevation(S, time_index, seed=123, phases=None):
+def surface_elevation(S, time_index, seed=123, frequency_bins=None,phases=None):
     """
     Calculates wave elevation time-series from spectrum
     
@@ -196,6 +197,8 @@ def surface_elevation(S, time_index, seed=123, phases=None):
         for example, time = np.arange(0,100,0.01)
     seed: int (optional)
         Random seed
+    frequency_bins: numpy array or pandas Series (optional)
+        Bin widths for frequency of S. Required for unevenly sized bins
     phases: numpy array or pandas DataFrame (optional)
         Explicit phases for frequency components (overrides seed)
         for example, phases = np.random.rand(len(S)) * 2 * np.pi
@@ -211,20 +214,34 @@ def surface_elevation(S, time_index, seed=123, phases=None):
     except:
         pass
     assert isinstance(S, pd.DataFrame), 'S must be of type pd.DataFrame'
-    assert isinstance(time_index, np.ndarray), 'time_index must be of type np.ndarray'
+    assert isinstance(time_index, np.ndarray), ('time_index must be of type' 
+            'np.ndarray')
     assert isinstance(seed, (type(None),int)), 'seed must be of type int'
-    assert isinstance(phases, (type(None),np.ndarray, pd.DataFrame)), 'phases must be of type np.ndarray'
+    assert isinstance(frequency_bins, (type(None), np.ndarray, pd.DataFrame)),( 
+            "frequency_bins must be of type None, np.ndarray, or pd,DataFrame")
+    assert isinstance(phases, (type(None), np.ndarray, pd.DataFrame)), (
+            'phases must be of type None, np.ndarray, or pd,DataFrame')
+
+    if frequency_bins is not None:
+        assert frequency_bins.squeeze().shape == frequency_bins.squeeze().shape,(
+            'shape of frequency_bins must match shape of S')
     if phases is not None:
-        assert phases.squeeze().shape == S.squeeze().shape, 'shape of phases must match S'
-    
-    
+        assert phases.squeeze().shape == S.squeeze().shape,( 
+            'shape of phases must match shape of S')
+        
     start_time = time_index[0]
     end_time = time_index[-1]
-    
-    f = pd.Series(S.index) # frequency
+
+    f = pd.Series(S.index)
     f.index = f
-    delta_f = f.diff()
-    
+        
+    if frequency_bins is None:        
+        delta_f = f.diff()
+    elif isinstance(frequency_bins, np.ndarray):
+        delta_f = pd.DataFrame(frequency_bins, index=S.index, columns=['df'])
+    elif isinstance(frequency_bins, pd.DataFrame):
+        delta_f = frequency_bins
+
     if phases is None:
         np.random.seed(seed)
         phase = pd.DataFrame(2*np.pi*np.random.rand(S.shape[0], S.shape[1]),
@@ -236,11 +253,12 @@ def surface_elevation(S, time_index, seed=123, phases=None):
         
     phase = phase[start_time:end_time] # Should phase, omega, and A*delta_f be 
                                         #   truncated before computation?
-    omega = pd.Series(2*np.pi*f) # angular freqency
+    
+    omega = pd.Series(2*np.pi*f) 
     omega.index = f
     omega = omega[start_time:end_time]
     
-        # Wave amplitude times delta f, truncated
+    # Wave amplitude times delta f, truncated
     A = 2*S 
     A = A.multiply(delta_f, axis=0)
     A = np.sqrt(A)
@@ -292,13 +310,12 @@ def frequency_moment(S, N, frequency_bins=None):
         delta_f[0] = f[1]-f[0]
     else:
          
-        assert isinstance(frequency_bins, (np.ndarray,pd.Series,pd.DataFrame)), 'frequency_bins must be of type np.ndarray or pd.Series'
+        assert isinstance(frequency_bins, (np.ndarray,pd.Series,pd.DataFrame)),(
+         'frequency_bins must be of type np.ndarray or pd.Series')
         delta_f = pd.Series(frequency_bins)
 
     delta_f.index = f
-    # print(f)
-    # print(delta_f.values)
-        
+# import ipdb; ipdb.set_trace()    
     m = spec.multiply(fn,axis=0).multiply(delta_f,axis=0)
     m = m.sum(axis=0)
     

--- a/mhkit/wave/resource.py
+++ b/mhkit/wave/resource.py
@@ -213,7 +213,7 @@ def surface_elevation(S, time_index, seed=123, phases=None):
     assert isinstance(S, pd.DataFrame), 'S must be of type pd.DataFrame'
     assert isinstance(time_index, np.ndarray), 'time_index must be of type np.ndarray'
     assert isinstance(seed, (type(None),int)), 'seed must be of type int'
-    assert isinstance(phases, np.ndarray), 'phases must be of type np.ndarray'
+    assert isinstance(phases, (type(None),np.ndarray)), 'phases must be of type np.ndarray'
     assert len(phases) == len(S), 'length of phases must match S'
     
     


### PR DESCRIPTION
Currently, you can set the random number generator feed for `surface_elevation` via the optional argument `seed`. However, it would also be nice to explicitly set the phases to some known values. This pull request provides this functionality via an additional optional argument `phases`.

https://github.com/MHKiT-Software/MHKiT-Python/blob/362f76b09ea411aae214c80df3d90f5eb4f02471/mhkit/wave/resource.py#L186