### PR TITLE
Change link formatting to render in documentation correctly

### DIFF
--- a/examples/river_example.ipynb
+++ b/examples/river_example.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# MHKiT River Module\n",
     "\n",
-    "The following example will familiarize the user with the [MHKIT river module](https://mhkit-software.github.io/MHKiT/mhkit-python/api.river.html) by stepping through the calculation of annual energy produced for one turbine in the Tanana river near Nenana, Alaska.  The data file used in this example is retrieved from the USGS website, additional data is stored in the [\\\\MHKiT\\examples\\data](https://github.com/MHKiT-Software/MHKiT-Python/tree/master/examples/data) directory.\n",
+    "The following example will familiarize the user with the [MHKIT river module](https://mhkit-software.github.io/MHKiT/mhkit-python/api.river.html) by stepping through the calculation of annual energy produced for one turbine in the Tanana river near Nenana, Alaska.  The data file used in this example is retrieved from the USGS website, a local version of the data is stored in the [\\\\\\\\MHKiT\\\\\\\\examples\\\\\\\\data](https://github.com/MHKiT-Software/MHKiT-Python/tree/master/examples/data) directory.\n",
     "\n",
     "Start by importing the necessary python packages and MHKiT module."
    ]
@@ -369,7 +369,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/tidal_example.ipynb
+++ b/examples/tidal_example.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# MHKiT Tidal Module\n",
     "\n",
-    "The following example will familiarize the user with the [MHKiT tidal module](https://mhkit-software.github.io/MHKiT/mhkit-python/api.tidal.html) by stepping through the calculation of the velocity duration curve. The data file used in this example is stored in the [\\\\MHKiT\\examples\\data](https://github.com/MHKiT-Software/MHKiT-Python/tree/master/examples/data) directory.\n",
+    "The following example will familiarize the user with the [MHKiT tidal module](https://mhkit-software.github.io/MHKiT/mhkit-python/api.tidal.html) by stepping through the calculation of the velocity duration curve. The data file used in this example is stored in the [\\\\\\\\MHKiT\\\\\\\\examples\\\\\\\\data](https://github.com/MHKiT-Software/MHKiT-Python/tree/master/examples/data) directory.\n",
     "\n",
     "Start by importing the necessary MHKiT module."
    ]
@@ -316,7 +316,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updating the link formatting to render in the documentation correctly. Once updated here this should pull into the documentation submodule.