### PR TITLE
request_wpto_directional_spectrum improvements

### DIFF
--- a/mhkit/tests/test_wave.py
+++ b/mhkit/tests/test_wave.py
@@ -1045,7 +1045,7 @@ class TestWPTOhindcast(unittest.TestCase):
             meta_dir)=(wave.io.hindcast
                        .request_wpto_directional_spectrum(lat_lon,year='1995'))
             dir_multiyear = dir_multiyear.sel(time_index=slice(dir_multiyear.time_index[0],dir_multiyear.time_index[99]))
-            dir_multiyear = dir_multiyear.rename_vars({87:'87',58:'58'})
+            dir_multiyear = dir_multiyear.rename({87:'87',58:'58'})
 
             assert_frame_equal(self.ml,wave_multiloc)
             assert_frame_equal(self.ml_meta,meta)

--- a/mhkit/wave/io/hindcast.py
+++ b/mhkit/wave/io/hindcast.py
@@ -221,8 +221,9 @@ def request_wpto_directional_spectrum(lat_lon, year, tree=None,
         # get metadata
         col = data_raw.columns[:]
         meta = rex_waves.meta.loc[col,:]
-        meta = meta.reset_index(drop=True) 
+        meta = meta.reset_index(drop=True)
 
-    data = data_raw.to_xarray()
+    data = data_raw.to_xarray().to_array().drop('variable').squeeze()
+    data['time_index'] = pd.to_datetime(data.time_index)
 
-    return data, meta    
+    return data, meta, data_raw

--- a/mhkit/wave/io/hindcast.py
+++ b/mhkit/wave/io/hindcast.py
@@ -226,4 +226,4 @@ def request_wpto_directional_spectrum(lat_lon, year, tree=None,
     data = data_raw.to_xarray().to_array().drop('variable').squeeze()
     data['time_index'] = pd.to_datetime(data.time_index)
 
-    return data, meta, data_raw
+    return data, meta


### PR DESCRIPTION
Update the `wave.io.hindcast.request_wpto_directional_spectrum` function to:

1. Use `datetime` objects
2. Create a `DataArray` (not `Dataset` with weird variable naming)