### PR TITLE
Fix: update variable name to remove reference before assignment error

### DIFF
--- a/mhkit/wave/contours.py
+++ b/mhkit/wave/contours.py
@@ -1752,7 +1752,7 @@ def samples_contour(t_samples, t_contour, hs_contour):
     w2 = np.concatenate((hs_contour[aamax:], hs_contour[:aamin]))
     if (np.max(w1) > np.max(w2)):
         x1 = t_contour[aamin:aamax]
-        y = hs_contour[aamin:aamax]
+        y1 = hs_contour[aamin:aamax]
     else:
         x1 = np.concatenate((t_contour[aamax:], t_contour[:aamin]))
         y1 = np.concatenate((hs_contour[aamax:], hs_contour[:aamin]))


### PR DESCRIPTION
Snippet from error (happens a bit after the changed line in PR): 
```
 y = y1[ms]
UnboundLocalError: local variable 'y1' referenced before assignment
```

