### PR TITLE
Run CI on push to Develop

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,9 @@ name: Py 3.7 3.8, 3.9 | Windows Mac Linux
 
 on:
   push:
-    branches: [master]
+    branches: 
+      - master
+      - Develop
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Currently, we are not running tests when pushing to the Develop branch.

This will enable CI tests on push to the Develop branch