### PR TITLE
Fix type for return_year in extreme.return_year_value

### DIFF
--- a/mhkit/loads/extreme.py
+++ b/mhkit/loads/extreme.py
@@ -749,7 +749,7 @@ def return_year_value(ppf, return_year, short_term_period_hr):
         The value corresponding to the return period from the distribution.
     """
     assert callable(ppf)
-    assert isinstance(return_year, int)
+    assert isinstance(return_year, (float, int))
     assert isinstance(short_term_period_hr, (float, int))
 
     p = 1 / (return_year * 365.25 * 24 / short_term_period_hr)

--- a/mhkit/tests/loads/test_loads.py
+++ b/mhkit/tests/loads/test_loads.py
@@ -181,13 +181,17 @@ class TestWDRT(unittest.TestCase):
         assert_frame_equal(self.mler_ts, mler_ts, atol=0.0001)
 
     def test_return_year_value(self):
+        return_years = [50, 50.0]
+        short_term_periods = [1, 1.0]
         dist = stats.norm
-        return_year = 50
-        short_term_period = 1
 
-        val = loads.extreme.return_year_value(dist.ppf, return_year, short_term_period)
-        want = 4.5839339
-        self.assertAlmostEqual(want, val, 5)
+        for y in return_years:
+            for stp in short_term_periods:
+                with self.subTest(year=y, short_term=stp):
+                    val = loads.extreme.return_year_value(
+                        dist.ppf, y, stp)
+                    want = 4.5839339
+                    self.assertAlmostEqual(want, val, 5)
 
     def test_longterm_extreme(self):
         ste_1 = stats.norm


### PR DESCRIPTION
In an oversight in merging #193 the docstring was updated for the type of return_year in return_year_value but the corresponding assertion was not.

Tests for the types of the two input parameters have been added to try to avoid a simular situation occuring the future.