### PR TITLE
Release to pypi github actions workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,45 @@
+# Builds mhkit and publishes to testpypi.org on every commit to master. On tagged commits, also publishes to pypi.org.
+# https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+name: Build and release 🐍 📦
+
+on:
+  push:
+    branches:
+      - master
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish:
+    name: Build and release 🐍 📦
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - run: python -m pip install build --user
+      - run: python -m build --sdist --wheel --outdir dist/ .
+
+      - name: Upload to Test PyPI
+        if: github.repository_owner == 'MHKiT-Software'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+      - name: Upload to PyPI (tagged release only)
+        if:
+          github.repository_owner == 'MHKiT-Software' && github.event_name == 'release' &&
+          github.event.action == 'published'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <a href=https://pepy.tech/project/mhkit>
         <img src="https://pepy.tech/badge/mhkit">
     </a>
-    <a href=https://doi.org/10.5281/zenodo.392468>
+    <a href=https://doi.org/10.5281/zenodo.3924683>
         <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.3924683.svg">
     </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 ![](figures/logo.png) MHKiT-Python
 =====================================
 
-[![Py 3.8,3.9 | Windows Mac Linux](https://github.com/MHKiT-Software/MHKiT-Python/actions/workflows/main.yml/badge.svg)](https://github.com/MHKiT-Software/MHKiT-Python/actions/workflows/main.yml)
-[![Coverage Status](https://coveralls.io/repos/github/MHKiT-Software/MHKiT-Python/badge.svg?branch=master)](https://coveralls.io/github/MHKiT-Software/MHKiT-Python?branch=master)
-[![Downloads](https://pepy.tech/badge/mhkit)](https://pepy.tech/project/mhkit)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3924683.svg)](https://doi.org/10.5281/zenodo.3924683)
-
+<p align="left">
+    <a href=https://github.com/MHKiT-Software/MHKiT-Python/actions/workflows/main.yml>
+        <img src="https://github.com/MHKiT-Software/MHKiT-Python/actions/workflows/main.yml/badge.svg">
+    </a>
+    <a href=https://coveralls.io/github/MHKiT-Software/MHKiT-Python?branch=master>
+        <img src="https://coveralls.io/repos/github/MHKiT-Software/MHKiT-Python/badge.svg?branch=master">
+    </a>
+    <a href=https://pepy.tech/project/mhkit>
+        <img src="https://pepy.tech/badge/mhkit">
+    </a>
+    <a href=https://doi.org/10.5281/zenodo.392468>
+        <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.3924683.svg">
+    </a>
+</p>
 
 MHKiT-Python is a Python package designed for marine renewable energy applications to assist in 
 data processing and visualization.  The software package include functionality for:


### PR DESCRIPTION
This PR adds a github actions workflow that releases to test.pypi.org on every commit to master and to pypi.org on every published release. It requires setting two repository secrets:

1. TEST_PYPI_API_TOKEN
2. PYPI_API_TOKEN

I also updated the badges in the README to use html `img` tags instead of markdown so that they will show up correctly on pypi.org. Previously it looked like this:

<img width="806" alt="image" src="https://github.com/MHKiT-Software/MHKiT-Python/assets/24307537/72eaf061-684e-4175-92c6-20d5fdc6418d">

