### PR TITLE
Run hindcast tests only on change to hindcast module

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -241,18 +241,6 @@ jobs:
           COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
           COVERALLS_PARALLEL: true
 
-  log:
-    needs: [conda-build, pip-build, hindcast-calls]
-    runs-on: ubuntu-latest
-    container: python:3-slim
-    steps:
-      - name: Log job results
-        run: |
-          always() &&
-          echo conda-build result: ${{ needs.conda-build.result }}
-          echo pip-build result: ${{ needs.pip-build.result }}
-          echo hindcast-calls result: ${{ needs.hindcast-calls.result }}
-
   coveralls:
     name: Indicate completion to coveralls.io
     needs: [conda-build, pip-build, hindcast-calls]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       wave_io_hindcast_changed: ${{ steps.changes.outputs.wave_io_hindcast }}
+      should-run-hindcast: ${{ steps.hindcast-logic.outputs.should-run-hindcast }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -25,6 +26,14 @@ jobs:
           filters: |
             wave_io_hindcast:
               - 'mhkit/tests/wave/io/hindcast/**'
+
+      - id: hindcast-logic
+        run: |
+          if [[ "${{ github.event.pull_request.base.ref }}" == "master" || "${{ steps.changes.outputs.wave_io_hindcast }}" == "true" ]]; then
+            echo "::set-output name=should-run-hindcast::true"
+          else
+            echo "::set-output name=should-run-hindcast::false"
+          fi
 
   prepare-cache:
     needs: [check-changes]
@@ -178,23 +187,10 @@ jobs:
           COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
           COVERALLS_PARALLEL: true
 
-  hindcast-logic:
-    runs-on: ubuntu-latest
-    outputs:
-      should-run-hindcast: ${{ steps.hindcast-logic.outputs.should-run-hindcast }}
-    steps:
-      - id: hindcast-logic
-        run: |
-          if [[ "${{ github.event.pull_request.base.ref }}" == "master" || "${{ needs.check-changes.outputs.wave_io_hindcast_changed }}" == "true" ]]; then
-            echo "::set-output name=should-run-hindcast::true"
-          else
-            echo "::set-output name=should-run-hindcast::false"
-          fi
-
   hindcast-calls:
     name: hindcast-${{ matrix.os }}/${{ matrix.python-version }}
     needs: [check-changes, prepare-cache]
-    if: (github.event.pull_request.base.ref == 'master' || needs.check-changes.outputs.wave_io_hindcast_changed == 'true')
+    if: (needs.check-changes.outputs.should-run-hindcast == 'true')
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -241,6 +241,17 @@ jobs:
           COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
           COVERALLS_PARALLEL: true
 
+  log:
+    needs: [conda-build, pip-build, hindcast-calls]
+    runs-on: ubuntu-latest
+    container: python:3-slim
+    steps:
+      - name: Log job results
+        run: |
+          echo conda-build result: ${{ needs.conda-build.result }}
+          echo pip-build result: ${{ needs.pip-build.result }}
+          echo hindcast-calls result: ${{ needs.hindcast-calls.result }}
+
   coveralls:
     name: Indicate completion to coveralls.io
     needs: [conda-build, pip-build, hindcast-calls]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         uses: dorny/paths-filter@v2
         with:
           filters: |
-            wave_io_hindcast:  # Adjusted the filter name
+            wave_io_hindcast:
               - 'mhkit/tests/wave/io/hindcast/**'
 
   prepare-cache:
@@ -64,7 +64,7 @@ jobs:
           pytest mhkit/tests/wave/io/test_cdip.py
 
       - name: Prepare Hindcast data
-        if: needs.check-changes.outputs.wave_io_hindcast_changed == 'true'
+        if: (github.event.pull_request.base.ref == 'master' || needs.check-changes.outputs.wave_io_hindcast_changed == 'true')
         run: |
           # pytest tests/test_specific_file.py::TestClass::test_function
           source activate TEST
@@ -181,7 +181,8 @@ jobs:
   hindcast-calls:
     name: hindcast-${{ matrix.os }}/${{ matrix.python-version }}
     needs: [check-changes, prepare-cache]
-    if: needs.check-changes.outputs.wave_io_hindcast_changed == 'true'
+
+    if: (github.event.pull_request.base.ref == 'master' || needs.check-changes.outputs.wave_io_hindcast_changed == 'true')
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,11 +178,24 @@ jobs:
           COVERALLS_FLAG_NAME: ${{ matrix.python-version }}
           COVERALLS_PARALLEL: true
 
+  hindcast-logic:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run-hindcast: ${{ steps.hindcast-logic.outputs.should-run-hindcast }}
+    steps:
+      - id: hindcast-logic
+        run: |
+          if [[ "${{ github.event.pull_request.base.ref }}" == "master" || "${{ needs.check-changes.outputs.wave_io_hindcast_changed }}" == "true" ]]; then
+            echo "::set-output name=should-run-hindcast::true"
+          else
+            echo "::set-output name=should-run-hindcast::false"
+          fi
+
   hindcast-calls:
     name: hindcast-${{ matrix.os }}/${{ matrix.python-version }}
     needs: [check-changes, prepare-cache]
-
     if: (github.event.pull_request.base.ref == 'master' || needs.check-changes.outputs.wave_io_hindcast_changed == 'true')
+
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 1
@@ -235,6 +248,7 @@ jobs:
   coveralls:
     name: Indicate completion to coveralls.io
     needs: [conda-build, pip-build, hindcast-calls]
+    if: always() && (needs.hindcast-calls.result == 'success' || needs.hindcast-calls.result == 'skipped')
     runs-on: ubuntu-latest
     container: python:3-slim
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -244,7 +244,10 @@ jobs:
   coveralls:
     name: Indicate completion to coveralls.io
     needs: [conda-build, pip-build, hindcast-calls]
-    if: always() && (needs.hindcast-calls.result == 'success' || needs.hindcast-calls.result == 'skipped')
+    if: |
+      needs.conda-build.result == 'success' &&
+      needs.pip-build.result == 'success' &&
+      (needs.hindcast-calls.result == 'success' || needs.hindcast-calls.result == 'skipped')
     runs-on: ubuntu-latest
     container: python:3-slim
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -248,6 +248,7 @@ jobs:
     steps:
       - name: Log job results
         run: |
+          always() &&
           echo conda-build result: ${{ needs.conda-build.result }}
           echo pip-build result: ${{ needs.pip-build.result }}
           echo hindcast-calls result: ${{ needs.hindcast-calls.result }}
@@ -256,6 +257,7 @@ jobs:
     name: Indicate completion to coveralls.io
     needs: [conda-build, pip-build, hindcast-calls]
     if: |
+      always() &&
       needs.conda-build.result == 'success' &&
       needs.pip-build.result == 'success' &&
       (needs.hindcast-calls.result == 'success' || needs.hindcast-calls.result == 'skipped')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
           pytest mhkit/tests/wave/io/test_cdip.py
 
       - name: Prepare Hindcast data
-        if: (github.event.pull_request.base.ref == 'master' || needs.check-changes.outputs.wave_io_hindcast_changed == 'true')
+        if: (needs.check-changes.outputs.should-run-hindcast == 'true')
         run: |
           # pytest tests/test_specific_file.py::TestClass::test_function
           source activate TEST

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,24 @@ on:
       - master
       - develop
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      wave_io_hindcast_changed: ${{ steps.changes.outputs.wave_io_hindcast }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Check for changes in wave/io/hindcast
+        id: changes
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            wave_io_hindcast:  # Adjusted the filter name
+              - 'mhkit/tests/wave/io/hindcast/**'
+
   prepare-cache:
+    needs: [check-changes]
     runs-on: ubuntu-latest
     env:
       PYTHON_VER: 3.9
@@ -41,11 +58,16 @@ jobs:
 
       - name: Prepare data
         run: |
-          # pytest tests/test_specific_file.py::TestClass::test_function
           source activate TEST
           pytest mhkit/tests/river/test_io.py
           pytest mhkit/tests/tidal/test_io.py
           pytest mhkit/tests/wave/io/test_cdip.py
+
+      - name: Prepare Hindcast data
+        if: needs.check-changes.outputs.wave_io_hindcast_changed == 'true'
+        run: |
+          # pytest tests/test_specific_file.py::TestClass::test_function
+          source activate TEST
           pytest mhkit/tests/wave/io/hindcast/test_hindcast.py
           pytest mhkit/tests/wave/io/hindcast/test_wind_toolkit.py
 
@@ -158,7 +180,8 @@ jobs:
 
   hindcast-calls:
     name: hindcast-${{ matrix.os }}/${{ matrix.python-version }}
-    needs: [prepare-cache]
+    needs: [check-changes, prepare-cache]
+    if: needs.check-changes.outputs.wave_io_hindcast_changed == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 1


### PR DESCRIPTION
This Pull Request introduces a mechanism to selectively trigger the execution of expensive hindcast tests based on the context of the changes made. Specifically, the hindcast tests will only run under two scenarios:

1. If there are changes made to the modules within the `mhkit/wave/io/hindcast` directory.
2. If the merge request is targeted at the `master` branch.

To achieve this, a new job named `check-changes` has been added to the workflow, which precedes the `prepare-cache` job.

![image](https://github.com/MHKiT-Software/MHKiT-Python/assets/13438942/89b68471-62b7-4f5a-88d0-1d3515ab1923)


Here's how the check-changes job operates:

1. Detecting Module Changes:
    - Check if any files within the `mhkit/wave/io/hindcast` directory have been altered.
      - If yes, set `wave_io_hindcast_changed` to true.
      - If no, set `wave_io_hindcast_changed` to false.
2. Determining Hindcast Test Execution:
    - Check if the PR is against the master branch or if `wave_io_hindcast_changed` is true.
    - If either condition is met, set `should-run-hindcast` to true.
      - Otherwise, set `should-run-hindcast` to false.

Some additional minor modifications have been made to ensure the seamless integration of Coveralls reporting, regardless of whether the hindcast tests are executed or skipped.

