### PR TITLE
Skip junk headers in AD2CP files

### DIFF
--- a/mhkit/dolfyn/io/nortek.py
+++ b/mhkit/dolfyn/io/nortek.py
@@ -56,9 +56,7 @@ def read_nortek(
 
     userdata = _find_userdata(filename, userdata)
 
-    rdr = _NortekReader(
-        filename, debug=debug, do_checksum=do_checksum, nens=nens
-    )
+    rdr = _NortekReader(filename, debug=debug, do_checksum=do_checksum, nens=nens)
     rdr.readfile()
     rdr.dat2sci()
     dat = rdr.data
@@ -1210,6 +1208,7 @@ class _NortekReader:
         for nm in ["data_header", "checkdata"]:
             if nm in self.config and isinstance(self.config[nm], list):
                 self.config[nm] = _recatenate(self.config[nm])
+
 
 def _crop_data(obj, range, n_lastdim):
     for nm, dat in obj.items():

--- a/mhkit/dolfyn/io/nortek2.py
+++ b/mhkit/dolfyn/io/nortek2.py
@@ -133,7 +133,9 @@ class _Ad2cpReader:
         self.f.seek(0, 2)  # Seek to end
         self._eof = self.f.tell()
         self.start_pos = self._check_header()
-        self._index = lib.get_index(fname, pos=self.start_pos, reload=rebuild_index, debug=debug)
+        self._index = lib.get_index(
+            fname, pos=self.start_pos, reload=rebuild_index, debug=debug
+        )
         self._reopen(bufsize)
         self.filehead_config = self._read_filehead_config_string()
         self._ens_pos = self._index["pos"][
@@ -175,11 +177,12 @@ class _Ad2cpReader:
             while idx != -1:
                 yield idx
                 idx = s.find(c, idx + 1)
+
         # Guess that a header won't be longer than 10,000 bytes
         self._reopen(10000)
         pk = self.f.peek(1)
         # Search for multiple saved headers
-        found = [i for i in find_all(pk, b'GETCLOCKSTR')]
+        found = [i for i in find_all(pk, b"GETCLOCKSTR")]
         if len(found) < 2:
             return 0
         else:

--- a/mhkit/dolfyn/io/nortek2.py
+++ b/mhkit/dolfyn/io/nortek2.py
@@ -134,7 +134,7 @@ class _Ad2cpReader:
         self._eof = self.f.tell()
         self.start_pos = self._check_header()
         self._index = lib.get_index(
-            fname, pos=self.start_pos, reload=rebuild_index, debug=debug
+            fname, pos=self.start_pos, eof=self._eof, reload=rebuild_index, debug=debug
         )
         self._reopen(bufsize)
         self.filehead_config = self._read_filehead_config_string()

--- a/mhkit/dolfyn/io/nortek2.py
+++ b/mhkit/dolfyn/io/nortek2.py
@@ -178,8 +178,8 @@ class _Ad2cpReader:
                 yield idx
                 idx = s.find(c, idx + 1)
 
-        # Guess that a header won't be longer than 10,000 bytes
-        self._reopen(10000)
+        # Open the entire file
+        self._reopen(self._eof)
         pk = self.f.peek(1)
         # Search for multiple saved headers
         found = [i for i in find_all(pk, b"GETCLOCKSTR")]

--- a/mhkit/dolfyn/io/nortek2_lib.py
+++ b/mhkit/dolfyn/io/nortek2_lib.py
@@ -203,6 +203,10 @@ def _create_index(infile, outfile, init_pos, eof, debug):
                     )
                 )
         else:
+            if dat[4] < 0:
+                if debug:
+                    logging.info("Invalid skip byte at pos: %10d\n" % (pos))
+                break
             fin.seek(dat[4], 1)
     fin.close()
     fout.close()

--- a/mhkit/dolfyn/io/nortek2_lib.py
+++ b/mhkit/dolfyn/io/nortek2_lib.py
@@ -144,6 +144,9 @@ def _create_index(infile, outfile, N_ens, debug):
         if dat[2] in ids:
             idk = dat[2]
             d_ver, d_off, config = struct.unpack("<BBH", fin.read(4))
+            if d_ver not in [0, 3]:
+                # 0 for bottom track, 3 for all others
+                continue
             fin.seek(4, 1)
             yr, mo, dy, h, m, s, u = struct.unpack("6BH", fin.read(8))
             fin.seek(14, 1)
@@ -181,7 +184,7 @@ def _create_index(infile, outfile, N_ens, debug):
             fin.seek(dat[4] - (36 + seek_2ens[idk]), 1)
             last_ens[idk] = ens[idk]
 
-            if debug and N[idk] < 5:
+            if debug:
                 # hex: [18, 15, 1C, 17] = [vel_b5, vel, echo, bt]
                 logging.info(
                     "%10d: %02X, %d, %02X, %d, %d, %d, %d\n"

--- a/mhkit/dolfyn/io/nortek2_lib.py
+++ b/mhkit/dolfyn/io/nortek2_lib.py
@@ -107,7 +107,7 @@ def _calc_time(year, month, day, hour, minute, second, usec, zero_is_bad=True):
     return dt
 
 
-def _create_index(infile, outfile, N_ens, init_pos, debug):
+def _create_index(infile, outfile, init_pos, eof, debug):
     logging = getLogger()
     print("Indexing {}...".format(infile), end="")
     fin = open(_abspath(infile), "rb")
@@ -135,7 +135,8 @@ def _create_index(infile, outfile, N_ens, init_pos, debug):
         35: 40,
         36: 40,
     }
-    while N[21] < N_ens:  # Will fail if velocity ping isn't saved first
+    pos = 0
+    while pos <= eof:
         pos = fin.tell()
         if init_pos and not pos:
             fin.seek(init_pos, 1)
@@ -259,7 +260,7 @@ def _boolarray_firstensemble_ping(index):
     return dens
 
 
-def get_index(infile, pos=0, reload=False, debug=False):
+def get_index(infile, pos=0, eof=2**32, reload=False, debug=False):
     """
     This function reads ad2cp.index files
 
@@ -280,7 +281,7 @@ def get_index(infile, pos=0, reload=False, debug=False):
 
     index_file = infile + ".index"
     if not path.isfile(index_file) or reload:
-        _create_index(infile, index_file, 2**32, pos, debug)
+        _create_index(infile, index_file, pos, eof, debug)
     f = open(_abspath(index_file), "rb")
     file_head = f.read(12)
     if file_head[:10] == b"Index Ver:":


### PR DESCRIPTION
Adds logic to skip the messy header data that can accumulate during measurements collected via the Nortek software on a PC/Mac. Fix for #286 