### PR TITLE
Fix Failing test on `develop`

### DIFF
--- a/examples/adcp_example.ipynb
+++ b/examples/adcp_example.ipynb
@@ -3645,7 +3645,7 @@
     "f_rng = [0.2, 0.5]\n",
     "# Dissipation rate\n",
     "ds_avg[\"dissipation_rate_5m\"] = avg_tool.dissipation_rate_LT83(\n",
-    "    ds_avg[\"auto_spectra_5m\"], U, freq_range=f_rng, noise=ds_avg['noise_5m']\n",
+    "    ds_avg[\"auto_spectra_5m\"], U, freq_range=f_rng, noise=ds_avg[\"noise_5m\"]\n",
     ")"
    ]
   },
@@ -3673,10 +3673,10 @@
     "    spec[r] = avg_tool.power_spectral_density(\n",
     "        ds[\"vel_b5\"].isel(range_b5=r), freq_units=\"Hz\"\n",
     "    )\n",
-    "    \n",
+    "\n",
     "    # Calculate doppler noise from spectra from each depth bin\n",
     "    n[r] = avg_tool.doppler_noise_level(spec[r], pct_fN=0.9)\n",
-    "    \n",
+    "\n",
     "    # Calc dissipation rate from each spectra\n",
     "    e[r] = avg_tool.dissipation_rate_LT83(\n",
     "        spec[r], ds_avg.velds.U_mag.isel(range=r), freq_range=f_rng, noise=n[r]\n",
@@ -3794,7 +3794,9 @@
     }
    ],
    "source": [
-    "ds_avg[\"turbulence_intensity\"] = avg_tool.turbulence_intensity(ds.velds.U_mag, noise=ds_avg[\"noise\"])\n",
+    "ds_avg[\"turbulence_intensity\"] = avg_tool.turbulence_intensity(\n",
+    "    ds.velds.U_mag, noise=ds_avg[\"noise\"]\n",
+    ")\n",
     "\n",
     "(ds_avg[\"TI\"] - ds_avg[\"turbulence_intensity\"]).plot(cmap=\"Greens\", ylim=(0, 11))\n",
     "plt.title(\"TI Difference\")"

--- a/mhkit/loads/graphics.py
+++ b/mhkit/loads/graphics.py
@@ -180,9 +180,15 @@ def plot_bin_statistics(
     for i, variable in enumerate(input_variables):
         input_variables[i] = to_numeric_array(variable, variable_names[i])
 
-    bin_centers, bin_mean, bin_max, bin_min, bin_mean_std, bin_max_std, bin_min_std = (
-        input_variables
-    )
+    (
+        bin_centers,
+        bin_mean,
+        bin_max,
+        bin_min,
+        bin_mean_std,
+        bin_max_std,
+        bin_min_std,
+    ) = input_variables
 
     x_label = kwargs.get("x_label", None)
     y_label = kwargs.get("y_label", None)

--- a/mhkit/tests/river/test_io_d3d.py
+++ b/mhkit/tests/river/test_io_d3d.py
@@ -107,7 +107,7 @@ class TestIO(unittest.TestCase):
         result = river.io.d3d.create_points(np.array([1, 2]), np.array([3]), 4)
         expected = pd.DataFrame({"x": [1, 2], "y": [3, 3], "waterdepth": [4, 4]})
         pd.testing.assert_frame_equal(
-            result, expected, check_dtype=False, check_names=False
+            result, expected, check_dtype=False, check_names=False, check_index_type=False
         )
 
     def test_create_points_user_made_two_arrays_one_point(self):
@@ -155,7 +155,7 @@ class TestIO(unittest.TestCase):
         )
 
         pd.testing.assert_frame_equal(
-            result, expected, check_dtype=False, check_names=False
+            result, expected, check_dtype=False, check_names=False, check_index_type=False
         )
 
     def test_create_points_array_like_inputs(self):
@@ -168,7 +168,7 @@ class TestIO(unittest.TestCase):
         )
 
         pd.testing.assert_frame_equal(
-            result, expected, check_dtype=False, check_names=False
+            result, expected, check_dtype=False, check_names=False, check_index_type=False
         )
 
     def test_variable_interpolation(self):

--- a/mhkit/tests/river/test_io_d3d.py
+++ b/mhkit/tests/river/test_io_d3d.py
@@ -107,7 +107,11 @@ class TestIO(unittest.TestCase):
         result = river.io.d3d.create_points(np.array([1, 2]), np.array([3]), 4)
         expected = pd.DataFrame({"x": [1, 2], "y": [3, 3], "waterdepth": [4, 4]})
         pd.testing.assert_frame_equal(
-            result, expected, check_dtype=False, check_names=False, check_index_type=False
+            result,
+            expected,
+            check_dtype=False,
+            check_names=False,
+            check_index_type=False,
         )
 
     def test_create_points_user_made_two_arrays_one_point(self):
@@ -155,7 +159,11 @@ class TestIO(unittest.TestCase):
         )
 
         pd.testing.assert_frame_equal(
-            result, expected, check_dtype=False, check_names=False, check_index_type=False
+            result,
+            expected,
+            check_dtype=False,
+            check_names=False,
+            check_index_type=False,
         )
 
     def test_create_points_array_like_inputs(self):
@@ -168,7 +176,11 @@ class TestIO(unittest.TestCase):
         )
 
         pd.testing.assert_frame_equal(
-            result, expected, check_dtype=False, check_names=False, check_index_type=False
+            result,
+            expected,
+            check_dtype=False,
+            check_names=False,
+            check_index_type=False,
         )
 
     def test_variable_interpolation(self):


### PR DESCRIPTION
Pulls to `develop` have been failing in the D3D module for an `int32` vs `int64` index in the d3d io module specifically on windows builds.

![image](https://github.com/MHKiT-Software/MHKiT-Python/assets/13438942/e99c7720-9549-4055-8c7b-18c12dbb7031)


This PR ignores those differences and thereby fixes the failing tests.

Example of test failure output below:
```
================================== FAILURES ===================================
_________________ TestIO.test_create_points_array_like_inputs _________________

self = <mhkit.tests.river.test_io_d3d.TestIO testMethod=test_create_points_array_like_inputs>

    def test_create_points_array_like_inputs(self):
        """
        Test array-like inputs such as lists.
        """
        result = river.io.d3d.create_points([1, 2], [3, 4], [5, 6])
        expected = pd.DataFrame(
            {"x": [1, 2, 1, 2], "y": [3, 4, 3, 4], "waterdepth": [5, 5, 6, 6]}
        )
    
>       pd.testing.assert_frame_equal(
            result, expected, check_dtype=False, check_names=False
        )

mhkit\tests\river\test_io_d3d.py:1[70](https://github.com/MHKiT-Software/MHKiT-Python/actions/runs/8558019568/job/23459345139#step:7:71): 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

left = Index([0, 1, 2, 3], dtype='int32', name='index')
right = RangeIndex(start=0, stop=4, step=1), obj = 'DataFrame.index'

    def _check_types(left, right, obj: str = "Index") -> None:
        if not exact:
            return
    
        assert_class_equal(left, right, exact=exact, obj=obj)
        assert_attr_equal("inferred_type", left, right, obj=obj)
    
        # Skip exact dtype checking when `check_categorical` is False
        if is_categorical_dtype(left.dtype) and is_categorical_dtype(right.dtype):
            if check_categorical:
                assert_attr_equal("dtype", left, right, obj=obj)
                assert_index_equal(left.categories, right.categories, exact=exact)
            return
    
>       assert_attr_equal("dtype", left, right, obj=obj)
E       AssertionError: DataFrame.index are different
E       
E       Attribute "dtype" are different
E       [left]:  int32
E       [right]: int64
 
 ```