### PR TITLE
Fix for wave xarray conversion

### DIFF
--- a/mhkit/tests/wave/io/hindcast/test_hindcast.py
+++ b/mhkit/tests/wave/io/hindcast/test_hindcast.py
@@ -176,7 +176,7 @@ class TestWPTOhindcast(unittest.TestCase):
         parameters = "significant_wave_height"
 
         wave_multiyear, meta = wave.io.hindcast.hindcast.request_wpto_point_data(
-            data_type, parameters, lat_lon, years, as_xarray=True
+            data_type, parameters, lat_lon, years, to_pandas=False
         )
         wave_multiyear_df = (
             wave_multiyear["significant_wave_height_0"]

--- a/mhkit/wave/io/hindcast/hindcast.py
+++ b/mhkit/wave/io/hindcast/hindcast.py
@@ -94,7 +94,7 @@ def request_wpto_point_data(
     str_decode=True,
     hsds=True,
     path=None,
-    to_pandas=False,
+    to_pandas=True,
 ):
     """
     Returns data from the WPTO wave hindcast hosted on AWS at the


### PR DESCRIPTION
This PR implements to minor fixes that should have been included in #302.
- restores default for ``to_pandas`` in ``wave.io.hindcast.hindcast`` to match the behavior the previous ``as_xarray`` flag (the flag name and logic are reversed)
- updates ``as_xarray`` flag in hindcast tests to ``to_pandas`` 