### PR TITLE
MHKiT Numpy < 2.0.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - beautifulsoup4
   - xarray
   - h5py>=3.6.0
-  - netcdf4>=1.5.8
+  - netcdf4>=1.5.8, <=1.6.5
   - pip:
       - pecos>=0.3.0
       - fatpack

--- a/environment.yml
+++ b/environment.yml
@@ -6,8 +6,8 @@ dependencies:
   - python>=3.8,<3.12
   - pip
   - pandas>=1.0.0
-  - numpy>=1.21.0
-  - scipy
+  - numpy>=1.21.0, <2.0.0
+  - scipy<=1.13.1
   - matplotlib
   - requests
   - lxml

--- a/mhkit/__init__.py
+++ b/mhkit/__init__.py
@@ -17,7 +17,7 @@ _rmc()
 # Ignore future warnings
 _warn.simplefilter(action="ignore", category=FutureWarning)
 
-__version__ = "v0.8.0"
+__version__ = "v0.8.1"
 
 __copyright__ = """
 Copyright 2019, Alliance for Sustainable Energy, LLC under the terms of 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pandas>=1.0.0
-numpy>=1.21.0
-scipy
+numpy>=1.21.0, <2.0.0
+scipy<=1.13.1
 matplotlib
 requests
 pecos>=0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ NREL-rex>=0.2.63
 six>=1.13.0
 h5py>=3.6.0
 h5pyd>=0.7.0
-netCDF4>=1.5.8
+netCDF4>=1.5.8, <=1.6.5
 xarray
 statsmodels
 bottleneck

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ CLASSIFIERS = [
 ]
 DEPENDENCIES = [
     "pandas>=1.0.0",
-    "numpy>=1.21.0",
-    "scipy",
+    "numpy>=1.21.0, <2.0.0",
+    "scipy<=1.13.1",
     "matplotlib",
     "requests",
     "pecos>=0.3.0",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ DEPENDENCIES = [
     "six>=1.13.0",
     "h5py>=3.6.0",
     "h5pyd >=0.7.0",
-    "netCDF4",
+    "netCDF4>=1.5.8, <=1.6.5",
     "xarray",
     "statsmodels",
     "pytz",

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ See the [MHKiT documentation](https://mhkit-software.github.io/MHKiT) for more i
 
 Installation
 ------------------------
-MHKiT-Python requires Python (3.7, 3.8, or 3.9) along with several Python 
+MHKiT-Python requires Python (3.8, 3.9, 3.10, or 3.11) along with several Python 
 package dependencies.  MHKiT-Python can be installed from PyPI using the command ``pip install mhkit``.
 See [installation instructions](https://mhkit-software.github.io/MHKiT/installation.html) for more information.
 


### PR DESCRIPTION
This PR will fix testing and installation issues associated with numpy 2.0.0 until all required packages support.