### PR TITLE
Improve `surface_elevation` internal method selection

### DIFF
--- a/mhkit/tests/wave/test_resource_spectrum.py
+++ b/mhkit/tests/wave/test_resource_spectrum.py
@@ -158,6 +158,25 @@ class TestResourceSpectrum(unittest.TestCase):
 
         assert_allclose(eta_ifft, eta_sos)
 
+    def test_surface_elevation_uses_sum_of_sines_when_input_frequency_index_does_not_have_zero(self):
+        f = np.linspace(1 / 30, 1 / 2, 32)
+        S = wave.resource.jonswap_spectrum(f, self.Tp, self.Hs)
+
+        eta_default = wave.resource.surface_elevation(S, self.t, seed=1)
+        eta_sos = wave.resource.surface_elevation(
+            S, self.t, seed=1, method="sum_of_sines"
+        )
+
+        assert_allclose(eta_default, eta_sos)
+
+    def test_surface_elevation_uses_ifft_when_input_frequency_index_has_zero(self):
+        S = wave.resource.jonswap_spectrum(self.f, self.Tp, self.Hs)
+
+        eta_default = wave.resource.surface_elevation(S, self.t, seed=1)
+        eta_ifft = wave.resource.surface_elevation(S, self.t, seed=1, method="ifft")
+
+        assert_allclose(eta_default, eta_ifft)
+
     def test_plot_spectrum(self):
         filename = abspath(join(plotdir, "wave_plot_spectrum.png"))
         if isfile(filename):

--- a/mhkit/tests/wave/test_resource_spectrum.py
+++ b/mhkit/tests/wave/test_resource_spectrum.py
@@ -8,6 +8,7 @@ import mhkit.wave as wave
 import pandas as pd
 import numpy as np
 import unittest
+import pytest
 import os
 
 
@@ -168,6 +169,15 @@ class TestResourceSpectrum(unittest.TestCase):
         )
 
         assert_allclose(eta_default, eta_sos)
+
+    def test_surface_elevation_warn_user_if_zero_frequency_not_defined_and_using_ifft(
+        self,
+    ):
+        f = np.linspace(1 / 30, 1 / 2, 32)
+        S = wave.resource.jonswap_spectrum(f, self.Tp, self.Hs)
+
+        with pytest.warns(UserWarning):
+            wave.resource.surface_elevation(S, self.t, seed=1, method="ifft")
 
     def test_surface_elevation_uses_ifft_when_input_frequency_index_has_zero(self):
         S = wave.resource.jonswap_spectrum(self.f, self.Tp, self.Hs)

--- a/mhkit/wave/resource.py
+++ b/mhkit/wave/resource.py
@@ -1,3 +1,5 @@
+import warnings
+
 from scipy.optimize import fsolve as _fsolve
 from scipy import signal as _signal
 import pandas as pd
@@ -335,9 +337,10 @@ def surface_elevation(
 
     if method == "ifft":
         if not f[0] == 0:
-            raise ValueError(
-                f"ifft method must have zero frequency defined. Lowest frequency is: {S.index.values[0]}"
+            warnings.warn(
+                f"ifft method must have zero frequency defined. Lowest frequency is: {S.index.values[0]}. Setting method to less efficient `sum_of_sines` method."
             )
+            method = "sum_of_sines"
 
     if frequency_bins is None:
         delta_f = f.values[1] - f.values[0]

--- a/mhkit/wave/resource.py
+++ b/mhkit/wave/resource.py
@@ -338,7 +338,7 @@ def surface_elevation(
     if method == "ifft":
         if not f[0] == 0:
             warnings.warn(
-                f"ifft method must have zero frequency defined. Lowest frequency is: {S.index.values[0]}. Setting method to less efficient `sum_of_sines` method."
+                f"ifft method must have zero frequency defined. Lowest frequency is: {f[0].values}. Setting method to less efficient `sum_of_sines` method."
             )
             method = "sum_of_sines"
 


### PR DESCRIPTION
Updated the `surface_elevation` calculation method to default to `sum_of_sines` when zero frequency is absent in the input spectrum. A warning is issued to inform users of this change. This ensures users benefit from the fastest computation method without needing to understand the underlying calculations.





