### PR TITLE
Fix: Handle unnamed index/dimension in wave.resource.surface_elevation 

### DIFF
--- a/mhkit/tests/wave/test_resource_spectrum.py
+++ b/mhkit/tests/wave/test_resource_spectrum.py
@@ -148,6 +148,17 @@ class TestResourceSpectrum(unittest.TestCase):
 
         self.assertLess(rmse_sum, 0.02)
 
+    def test_spectrum_without_frequency_index_name_defined(self):
+        S = wave.resource.jonswap_spectrum(self.f, self.Tp, self.Hs)
+        S.index.name = None
+
+        eta_ifft = wave.resource.surface_elevation(S, self.t, seed=1, method="ifft")
+        eta_sos = wave.resource.surface_elevation(
+            S, self.t, seed=1, method="sum_of_sines"
+        )
+
+        assert_allclose(eta_ifft, eta_sos)
+
     def test_ifft_sum_of_sines(self):
         S = wave.resource.jonswap_spectrum(self.f, self.Tp, self.Hs)
 

--- a/mhkit/tests/wave/test_resource_spectrum.py
+++ b/mhkit/tests/wave/test_resource_spectrum.py
@@ -148,16 +148,26 @@ class TestResourceSpectrum(unittest.TestCase):
 
         self.assertLess(rmse_sum, 0.02)
 
-    def test_spectrum_without_frequency_index_name_defined(self):
+    def test_mhkit_spectrum_without_frequency_index_name_defined(self):
         S = wave.resource.jonswap_spectrum(self.f, self.Tp, self.Hs)
         S.index.name = None
 
-        eta_ifft = wave.resource.surface_elevation(S, self.t, seed=1, method="ifft")
-        eta_sos = wave.resource.surface_elevation(
+        eta_ifft_xr = wave.resource.surface_elevation(S, self.t, seed=1, method="ifft")
+        eta_sos_xr = wave.resource.surface_elevation(
             S, self.t, seed=1, method="sum_of_sines"
         )
 
-        assert_allclose(eta_ifft, eta_sos)
+        assert_allclose(eta_ifft_xr, eta_sos_xr)
+
+    def test_user_spectrum_without_frequency_index_name_defined(self):
+        spectra = pd.DataFrame({"magnitude": [1.0, 2.0, 3.0]}, index=[0.0, 1.0, 2.0])
+        time = [0.0, 1.0, 2.0]
+
+        result = wave.resource.surface_elevation(spectra, time, seed=1)
+
+        expected_magnitude = [-0.983917, 1.274248, -2.129812]
+
+        assert_allclose(result["magnitude"], expected_magnitude, atol=1e-6)
 
     def test_ifft_sum_of_sines(self):
         S = wave.resource.jonswap_spectrum(self.f, self.Tp, self.Hs)

--- a/mhkit/wave/resource.py
+++ b/mhkit/wave/resource.py
@@ -303,11 +303,6 @@ def surface_elevation(
     if frequency_dimension == "":
         frequency_dimension = list(S.coords)[0]
 
-        # If the first dimension name is not set rename it to "Frequency"
-        if frequency_dimension == "dim_0":
-            S = S.rename({"dim_0": "Frequency"})
-            frequency_dimension = list(S.coords)[0]
-
     elif frequency_dimension not in list(S.dims):
         raise ValueError(
             f"frequency_dimension is not a dimension of S ({list(S.dims)}). Got: {frequency_dimension}."
@@ -369,8 +364,8 @@ def surface_elevation(
             np.random.seed(seed)
             phase = xr.DataArray(
                 data=2 * np.pi * np.random.rand(S[var].size),
-                dims="Frequency",
-                coords={"Frequency": f},
+                dims=frequency_dimension,
+                coords={frequency_dimension: f},
             )
         else:
             phase = phases[var]
@@ -395,8 +390,8 @@ def surface_elevation(
             B = B.reshape((len(time_index), len(omega)))
             B = xr.DataArray(
                 data=B,
-                dims=["Time", "Frequency"],
-                coords={"Time": time_index, "Frequency": f},
+                dims=["Time", frequency_dimension],
+                coords={"Time": time_index, frequency_dimension: f},
             )
 
             # wave elevation

--- a/mhkit/wave/resource.py
+++ b/mhkit/wave/resource.py
@@ -302,6 +302,12 @@ def surface_elevation(
 
     if frequency_dimension == "":
         frequency_dimension = list(S.coords)[0]
+
+        # If the first dimension name is not set rename it to "Frequency"
+        if frequency_dimension == "dim_0":
+            S = S.rename({"dim_0": "Frequency"})
+            frequency_dimension = list(S.coords)[0]
+
     elif frequency_dimension not in list(S.dims):
         raise ValueError(
             f"frequency_dimension is not a dimension of S ({list(S.dims)}). Got: {frequency_dimension}."


### PR DESCRIPTION
Fix: If unnamed, set spectrum dim_0 name to "Frequency"

The surface_elevation function typically takes in a spectrum generated
by an mhkit function that sets the index/dimension name to "Frequency".
This fix handles an atypical case where the index/first dimension is
unnamed, which causes downstream issues where we are expecting a
dimension named "Frequency".

Per the [xarray DataArray documentation](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html)
an unnamed dimension starts at dim_0. If we find this case we
change the dim_0 name to "Frequency".