### PR TITLE
matplotlib >=3.8.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - pandas>=1.0.0
   - numpy>=1.21.0, <2.0.0
   - scipy<=1.13.1
-  - matplotlib
+  - matplotlib>=3.8.0
   - requests
   - lxml
   - scikit-learn

--- a/mhkit/wave/contours.py
+++ b/mhkit/wave/contours.py
@@ -8,10 +8,7 @@ import scipy.interpolate as interp
 import numpy as np
 import warnings
 from mhkit.utils import to_numeric_array
-
 import matplotlib
-
-mpl_version = tuple(map(int, matplotlib.__version__.split(".")))
 
 
 # Contours
@@ -1696,10 +1693,7 @@ def _bivariate_KDE(x1, x2, bw, fit, nb_steps, Ndata_bivariate_KDE, kwargs):
     x1_bivariate_KDE = []
     x2_bivariate_KDE = []
 
-    if mpl_version < (3, 8):  # For versions before 3.8
-        segments = vals.allsegs[0]
-    else:
-        segments = [path.vertices for path in vals.get_paths()]
+    segments = [path.vertices for path in vals.get_paths()]
 
     for seg in segments:
         x1_bivariate_KDE.append(seg[:, 1])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pandas>=1.0.0
 numpy>=1.21.0, <2.0.0
 scipy<=1.13.1
-matplotlib
+matplotlib>=3.8.0
 requests
 pecos>=0.3.0
 fatpack

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ DEPENDENCIES = [
     "pandas>=1.0.0",
     "numpy>=1.21.0, <2.0.0",
     "scipy<=1.13.1",
-    "matplotlib",
+    "matplotlib>=3.8.0",
     "requests",
     "pecos>=0.3.0",
     "fatpack",


### PR DESCRIPTION
The latest version of matplotlib broke a previous check for matplotlib versions earlier than 3.8.0

This fix requires that matplotlib be at least 3.8.0 for MHKiT and removes the check.