### PR TITLE
Use `main` as Primary Branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,11 +3,11 @@ name: Py 3.10, 3.11, 3.12 | Windows Mac Linux
 on:
   push:
     branches:
-      - master
+      - main
       - develop
   pull_request:
     branches:
-      - master
+      - main
       - develop
 
 jobs:
@@ -44,7 +44,7 @@ jobs:
 
       - id: hindcast-logic
         run: |
-          if [[ "${{ github.event.pull_request.base.ref }}" == "master" || "${{ steps.changes.outputs.wave_io_hindcast }}" == "true" ]]; then
+          if [[ "${{ github.event.pull_request.base.ref }}" == "main" || "${{ steps.changes.outputs.wave_io_hindcast }}" == "true" ]]; then
             echo "should-run-hindcast=true" >> "$GITHUB_OUTPUT"
           else
             echo "should-run-hindcast=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,4 +1,4 @@
-# Builds mhkit and publishes to testpypi.org on every commit to master. On tagged commits, also publishes to pypi.org.
+# Builds mhkit and publishes to testpypi.org on every commit to main. On tagged commits, also publishes to pypi.org.
 # https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 
 name: Build and release 🐍 📦
@@ -6,7 +6,7 @@ name: Build and release 🐍 📦
 on:
   push:
     branches:
-      - master
+      - main
   release:
     types: [published]
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
     <a href=https://github.com/MHKiT-Software/MHKiT-Python/actions/workflows/main.yml>
         <img src="https://github.com/MHKiT-Software/MHKiT-Python/actions/workflows/main.yml/badge.svg">
     </a>
-    <a href=https://coveralls.io/github/MHKiT-Software/MHKiT-Python?branch=master>
-        <img src="https://coveralls.io/repos/github/MHKiT-Software/MHKiT-Python/badge.svg?branch=master">
+    <a href=https://coveralls.io/github/MHKiT-Software/MHKiT-Python?branch=main>
+        <img src="https://coveralls.io/repos/github/MHKiT-Software/MHKiT-Python/badge.svg?branch=main">
     </a>
     <a href=https://pepy.tech/project/mhkit>
         <img src="https://pepy.tech/badge/mhkit">
@@ -82,7 +82,7 @@ The GitHub platform has the branch feature that facilitates code contributions a
 1. Navigate to your fork of MHKiT-Python (see instructions above)
 2. Above the list of files, click **Branches**.
 3. Click **New Branch**.
-4. Enter a name for the branch. Be sure to select **MHKiT-Software/MHKiT-Python:master** as the source.
+4. Enter a name for the branch. Be sure to select **MHKiT-Software/MHKiT-Python:main** as the source.
 5. Click **Create branch**. You will now have a branch on your fork of MHKiT-Python that you can use to work with the code base.
 
 ## Creating a pull request

--- a/README.md
+++ b/README.md
@@ -33,14 +33,16 @@ See the [MHKiT documentation](https://mhkit-software.github.io/MHKiT) for more i
 ## Installation
 
 MHKiT-Python requires Python (3.10, 3.11, 3.12) along with several Python
-package dependencies. MHKiT-Python can be installed from PyPI using the command:
-
-`pip install mhkit`
-
-MHKiT can alternatively be installed using conda:
+package dependencies. MHKiT-Python can be installed using the Conda package manager:
 
 ```bash
 conda install -c conda-forge mhkit
+```
+
+MHKiT can alternatively be installed from PyPi using pip:
+
+```bash
+pip install mhkit
 ```
 
 See [installation instructions](https://mhkit-software.github.io/MHKiT/installation.html) for more information.

--- a/examples/qc_example.ipynb
+++ b/examples/qc_example.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# MHKiT Quality Control Module\n",
-    "The following example runs a simple quality control analysis on wave elevation data using the [MHKiT QC module](https://mhkit-software.github.io/MHKiT/mhkit-python/api.qc.html).  The data file used in this example is stored in the [\\\\\\\\MHKiT\\\\\\\\examples\\\\\\\\data](https://github.com/MHKiT-Software/MHKiT-Python/tree/master/examples/data) directory.\n",
+    "The following example runs a simple quality control analysis on wave elevation data using the [MHKiT QC module](https://mhkit-software.github.io/MHKiT/mhkit-python/api.qc.html).  The data file used in this example is stored in the [\\\\\\\\MHKiT\\\\\\\\examples\\\\\\\\data](https://github.com/MHKiT-Software/MHKiT-Python/tree/main/examples/data) directory.\n",
     "\n",
     "Start by importing the necessary Python packages and MHKiT modules."
    ]
@@ -438,7 +438,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },

--- a/examples/river_example.ipynb
+++ b/examples/river_example.ipynb
@@ -8,7 +8,7 @@
    "source": [
     "# MHKiT River Module\n",
     "\n",
-    "The following example will familiarize the user with the [MHKIT river module](https://mhkit-software.github.io/MHKiT/mhkit-python/api.river.html) by stepping through the calculation of annual energy produced for one turbine in the Tanana River near Nenana, Alaska.  The data file used in this example is retrieved from the USGS website, a local version of the data is stored in the [\\\\\\\\MHKiT\\\\\\\\examples\\\\\\\\data](https://github.com/MHKiT-Software/MHKiT-Python/tree/master/examples/data) directory.\n",
+    "The following example will familiarize the user with the [MHKIT river module](https://mhkit-software.github.io/MHKiT/mhkit-python/api.river.html) by stepping through the calculation of annual energy produced for one turbine in the Tanana River near Nenana, Alaska.  The data file used in this example is retrieved from the USGS website, a local version of the data is stored in the [\\\\\\\\MHKiT\\\\\\\\examples\\\\\\\\data](https://github.com/MHKiT-Software/MHKiT-Python/tree/main/examples/data) directory.\n",
     "\n",
     "Start by importing the necessary python packages and MHKiT module."
    ]
@@ -357,7 +357,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },

--- a/examples/tidal_example.ipynb
+++ b/examples/tidal_example.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# MHKiT Tidal Module\n",
     "\n",
-    "The following example will familiarize the user with the [MHKiT tidal module](https://mhkit-software.github.io/MHKiT/mhkit-python/api.tidal.html) by stepping through the calculation of the velocity duration curve. The data file used in this example is stored in the [\\\\\\\\MHKiT\\\\\\\\examples\\\\\\\\data](https://github.com/MHKiT-Software/MHKiT-Python/tree/master/examples/data) directory.\n",
+    "The following example will familiarize the user with the [MHKiT tidal module](https://mhkit-software.github.io/MHKiT/mhkit-python/api.tidal.html) by stepping through the calculation of the velocity duration curve. The data file used in this example is stored in the [\\\\\\\\MHKiT\\\\\\\\examples\\\\\\\\data](https://github.com/MHKiT-Software/MHKiT-Python/tree/main/examples/data) directory.\n",
     "\n",
     "Start by importing the necessary MHKiT module."
    ]
@@ -376,7 +376,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -391,11 +391,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.7"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "1b38577481a8c337d860514619746143ecc67292e11e5807b52b737c5351e332"
-   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR updates our git workflow to use `main` as the MHKiT default branch :
- Many modern projects use `main` as the default branch, aligning with the GitHub recommendation and broader conventions.
- There is some non-linear history in the previous rebase causing issues between `develop` & `master`
- `main` was created from the current `develop` branch creating a 1-to-1 liner history between `develop` and the new `main` branch