### PR TITLE
DOLFyN/RDI: Set  `fs` to NaN when typical calculation methods yield error (#408)

### DIFF
--- a/mhkit/dolfyn/io/rdi.py
+++ b/mhkit/dolfyn/io/rdi.py
@@ -124,7 +124,7 @@ def read_rdi(
 
     if len(dss) == 2:
         warnings.warn(
-            "\nTwo profiling configurations retrieved from file" "\nReturning first."
+            "\nTwo profiling configurations retrieved from file\nReturning first."
         )
 
     # Close handler

--- a/mhkit/dolfyn/io/rdi.py
+++ b/mhkit/dolfyn/io/rdi.py
@@ -1053,7 +1053,9 @@ class _RDIReader:
                 )
                 cfg["fs"] = np.nan
             else:
-                cfg["fs"] = 1 / (cfg["sec_between_ping_groups"] * cfg["pings_per_ensemble"])
+                cfg["fs"] = 1 / (
+                    cfg["sec_between_ping_groups"] * cfg["pings_per_ensemble"]
+                )
 
         # Save configuration data as attributes
         dat["attrs"] = cfg

--- a/mhkit/dolfyn/io/rdi.py
+++ b/mhkit/dolfyn/io/rdi.py
@@ -1044,7 +1044,16 @@ class _RDIReader:
         ) or ("sentinelv" in cfg["inst_model"].lower()):
             cfg["fs"] = round(1 / np.median(np.diff(dat["coords"]["time"])), 2)
         else:
-            cfg["fs"] = 1 / (cfg["sec_between_ping_groups"] * cfg["pings_per_ensemble"])
+            # Handle burst mode where sec_between_ping_groups or pings_per_ensemble may be 0
+            if cfg["sec_between_ping_groups"] == 0 or cfg["pings_per_ensemble"] == 0:
+                warnings.warn(
+                    "mhkit.dolfyn: Cannot calculate sampling rate for burst mode data with variable ping rate. "
+                    f"Setting fs to NaN. sec_between_ping_groups={cfg['sec_between_ping_groups']}, "
+                    f"pings_per_ensemble={cfg['pings_per_ensemble']}."
+                )
+                cfg["fs"] = np.nan
+            else:
+                cfg["fs"] = 1 / (cfg["sec_between_ping_groups"] * cfg["pings_per_ensemble"])
 
         # Save configuration data as attributes
         dat["attrs"] = cfg

--- a/mhkit/dolfyn/io/rdi.py
+++ b/mhkit/dolfyn/io/rdi.py
@@ -1044,12 +1044,13 @@ class _RDIReader:
         ) or ("sentinelv" in cfg["inst_model"].lower()):
             cfg["fs"] = round(1 / np.median(np.diff(dat["coords"]["time"])), 2)
         else:
-            # Handle burst mode where sec_between_ping_groups or pings_per_ensemble may be 0
-            if cfg["sec_between_ping_groups"] == 0 or cfg["pings_per_ensemble"] == 0:
+            # Handle edge case where sec_between_ping_groups is 0, likely indicating burst mode is active (issue #408)
+            if cfg["sec_between_ping_groups"] == 0:
                 warnings.warn(
-                    "mhkit.dolfyn: Cannot calculate sampling rate for burst mode data with variable ping rate. "
-                    f"Setting fs to NaN. sec_between_ping_groups={cfg['sec_between_ping_groups']}, "
-                    f"pings_per_ensemble={cfg['pings_per_ensemble']}."
+                    "mhkit.dolfyn: Setting fs (sample rate) to NaN because sec_between_ping_groups is zero. "
+                    "Per issue #408, burst mode operation pings as fast as possible with inconsistent timing, "
+                    "preventing accurate sample rate calculations. "
+                    "See https://github.com/MHKiT-Software/MHKiT-Python/issues/408"
                 )
                 cfg["fs"] = np.nan
             else:

--- a/mhkit/tests/dolfyn/test_read_io.py
+++ b/mhkit/tests/dolfyn/test_read_io.py
@@ -15,8 +15,6 @@ from mhkit.dolfyn.io.api import read_example as read
 import unittest
 import pytest
 import os
-import warnings
-import numpy as np
 
 make_data = False
 
@@ -118,72 +116,5 @@ class io_testcase(unittest.TestCase):
         with self.assertRaises(IOError):
             read(rfnm("AWAC_test01.nc"))
 
-    def test_rdi_burst_mode_division_by_zero(self):
-        """Test fix for GitHub issue 408: RDI burst mode division by zero"""
-        # Test the specific problematic code path by directly testing the division by zero scenario
-        
-        # Test case 1: sec_between_ping_groups = 0 should warn and set fs to NaN
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            
-            # Directly test the problematic calculation logic
-            sec_between_ping_groups = 0
-            pings_per_ensemble = 1
-            
-            if sec_between_ping_groups == 0 or pings_per_ensemble == 0:
-                warnings.warn(
-                    "mhkit.dolfyn: Cannot calculate sampling rate for burst mode data with variable ping rate. "
-                    f"Setting fs to NaN. sec_between_ping_groups={sec_between_ping_groups}, "
-                    f"pings_per_ensemble={pings_per_ensemble}."
-                )
-                fs = np.nan
-            else:
-                fs = 1 / (sec_between_ping_groups * pings_per_ensemble)
-            
-            # Check that warning was issued and fs is NaN
-            assert len(w) == 1
-            assert np.isnan(fs)
-        
-        # Test case 2: pings_per_ensemble = 0 should warn and set fs to NaN  
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            
-            sec_between_ping_groups = 1.0
-            pings_per_ensemble = 0
-            
-            if sec_between_ping_groups == 0 or pings_per_ensemble == 0:
-                warnings.warn(
-                    "mhkit.dolfyn: Cannot calculate sampling rate for burst mode data with variable ping rate. "
-                    f"Setting fs to NaN. sec_between_ping_groups={sec_between_ping_groups}, "
-                    f"pings_per_ensemble={pings_per_ensemble}."
-                )
-                fs = np.nan
-            else:
-                fs = 1 / (sec_between_ping_groups * pings_per_ensemble)
-            
-            assert len(w) == 1
-            assert np.isnan(fs)
-        
-        # Test case 3: Normal operation should not warn and calculate fs correctly
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            
-            sec_between_ping_groups = 2.0
-            pings_per_ensemble = 1
-            
-            if sec_between_ping_groups == 0 or pings_per_ensemble == 0:
-                warnings.warn(
-                    "mhkit.dolfyn: Cannot calculate sampling rate for burst mode data with variable ping rate. "
-                    f"Setting fs to NaN. sec_between_ping_groups={sec_between_ping_groups}, "
-                    f"pings_per_ensemble={pings_per_ensemble}."
-                )
-                fs = np.nan
-            else:
-                fs = 1 / (sec_between_ping_groups * pings_per_ensemble)
-            
-            # Check that no warning was issued and fs is calculated correctly
-            assert len(w) == 0
-            expected_fs = 1 / (2.0 * 1)
-            assert fs == expected_fs
         with self.assertRaises(Exception):
             save_netcdf(tp.dat_rdi, "test_save.fail")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,3 +133,6 @@ include-package-data = true
 
 [tool.setuptools.dynamic]
 version = {attr = "mhkit.__version__"} 
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
## Summary

Fix #408: ZeroDivisionError when reading RDI burst mode data files where `sec_between_ping_groups=0` causes division by zero in sampling frequency calculation.

## Changes

- Added check for `sec_between_ping_groups == 0` before calculation of `fs`.

  - When true, set `fs` to `NaN` with descriptive warning.

- Added test using `unittest.mock.patch` to verify fix behavior with burst mode configuration.

- Fixed pytest-asyncio deprecation warning in test configuration.

## Details

Per #408 RDI instruments in continuous burst mode set `sec_between_ping_groups=0` for maximum ping rate, causing ZeroDivisionError in:

```python
cfg["fs"] = 1 / (cfg["sec_between_ping_groups"] * cfg["pings_per_ensemble"])
```

The fix detects this condition and sets fs=NaN since burst mode operation with variable timing prevents reliable sampling rate determination using standard methods.

## Testing

Patch RDIReader.finalize to set `sec_between_ping_groups` to `0` and verify the fix prevents the `ZeroDivisionError`, sets `fs` to `np.nan` and warns the user.
