### PR TITLE
Branding: Update NLR branding

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2019, Alliance for Sustainable Energy, LLC under the terms of Contract DE-AC36-08GO28308, Battelle Memorial Institute under the terms of Contract DE-AC05-76RL01830, and National Technology & Engineering Solutions of Sandia, LLC under the terms of Contract DE-NA0003525. The U.S. Government retains certain rights in this software. 
+Copyright (c) 2019, Alliance for Energy Innovation, LLC under the terms of Contract DE-AC36-08GO28308, Battelle Memorial Institute under the terms of Contract DE-AC05-76RL01830, and National Technology & Engineering Solutions of Sandia, LLC under the terms of Contract DE-NA0003525. The U.S. Government retains certain rights in this software. 
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ See [installation instructions](https://mhkit-software.github.io/MHKiT/installat
 
 ## Copyright and license
 
-MHKiT-Python is copyright through the National Renewable Energy Laboratory,
+MHKiT-Python is copyright through the National Laboratory of the Rockies,
 Pacific Northwest National Laboratory, and Sandia National Laboratories.
 The software is distributed under the Revised BSD License.
 See [copyright and license](LICENSE.md) for more information.

--- a/mhkit/__init__.py
+++ b/mhkit/__init__.py
@@ -14,7 +14,7 @@ configure_warnings()
 __version__ = "v1.0.1"
 
 __copyright__ = """
-Copyright 2019, Alliance for Sustainable Energy, LLC under the terms of 
+Copyright 2019, Alliance for Energy Innovation, LLC under the terms of 
 Contract DE-AC36-08GO28308, Battelle Memorial Institute under the terms of 
 Contract DE-AC05-76RL01830, and National Technology & Engineering Solutions of 
 Sandia, LLC under the terms of Contract DE-NA0003525. The U.S. Government 

--- a/mhkit/dolfyn/velocity.py
+++ b/mhkit/dolfyn/velocity.py
@@ -412,10 +412,10 @@ class Velocity:
         """
         Coherent turbulent energy
 
-        Niel Kelley's 'coherent turbulence energy', which is the
+        Neil Kelley's 'coherent turbulence energy', which is the
         root-mean-square of the Reynold's stresses.
 
-        See: NREL Technical Report TP-500-52353
+        See: NLR Technical Report TP-500-52353
         """
         E_coh = (self.upwp_**2 + self.upvp_**2 + self.vpwp_**2) ** (0.5)
 


### PR DESCRIPTION
Update documentation to use National Laboratory of the Rockies per: https://www.energy.gov/eere/articles/energy-department-renames-nrel-national-lab-rockies

At this point in time <https://nrel.gov> is still active and <https://nlr.gov> does not work, so we are keeping the nrel.gov links the same.

Also the HSDS api endpoints:

`/nrel/US_wave/virtual_buoy/{region}/{region}_virtual_buoy_{year}.h5`
`/nrel/wtk/{region.lower()}/{region}_*.h5`
`/nlr/wtk/{region.lower()}-5min/{region}_*.h5`

In

```
mhkit/wave/io/hindcast/hindcast.py
mhkit/wave/io/hindcast/wind_toolkit.py
```

Are not updated yet, but may change in the future. 