### PR TITLE
Feature: Add python 3.13 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           miniconda-version: ${{ env.CONDA_MINICONDA_VERSION }}
           auto-update-conda: ${{ env.CONDA_AUTO_UPDATE_CONDA }}
@@ -125,7 +125,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           miniconda-version: ${{ env.CONDA_MINICONDA_VERSION }}
           auto-update-conda: ${{ env.CONDA_AUTO_UPDATE_CONDA }}
@@ -168,7 +168,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           miniconda-version: ${{ env.CONDA_MINICONDA_VERSION }}
           auto-update-conda: ${{ env.CONDA_AUTO_UPDATE_CONDA }}
@@ -216,7 +216,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           miniconda-version: ${{ env.CONDA_MINICONDA_VERSION }}
           auto-update-conda: ${{ env.CONDA_AUTO_UPDATE_CONDA }}
@@ -342,7 +342,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           miniconda-version: ${{ env.CONDA_MINICONDA_VERSION }}
           auto-update-conda: ${{ env.CONDA_AUTO_UPDATE_CONDA }}
@@ -561,7 +561,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           miniconda-version: ${{ env.CONDA_MINICONDA_VERSION }}
           auto-update-conda: ${{ env.CONDA_AUTO_UPDATE_CONDA }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -460,7 +460,7 @@ jobs:
       matrix:
         module:
           [wave, tidal, river, dolfyn, power, loads, mooring, acoustics, utils]
-        python-version: ['3.12', '3.13']
+        python-version: ['3.13']
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -237,7 +237,7 @@ jobs:
           pip install -e ".[all,dev]" --no-deps
 
       - name: Download data from artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: data
           path: ~/.cache/mhkit
@@ -286,7 +286,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download data from artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: data
           path: ~/.cache/mhkit
@@ -363,13 +363,13 @@ jobs:
           pip install -e ".[all,dev]" --no-deps
 
       - name: Download Wave Hindcast data from artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wave-hindcast-data
           path: ~/.cache/mhkit/wave-hindcast
 
       - name: Download Wind Hindcast data from artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wind-hindcast-data
           path: ~/.cache/mhkit/wind-hindcast
@@ -471,7 +471,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Download non-hindcast data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: data
           path: ~/.cache/mhkit
@@ -582,21 +582,21 @@ jobs:
           pip install -e ".[all,dev]" --no-deps
 
       - name: Download non-hindcast data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: data
           path: ~/.cache/mhkit
 
       - name: Download Wave Hindcast data (if available)
         if: (needs.check-changes.outputs.should-run-hindcast == 'true')
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wave-hindcast-data
           path: ~/.cache/mhkit/wave-hindcast
 
       - name: Download Wind Hindcast data (if available)
         if: (needs.check-changes.outputs.should-run-hindcast == 'true')
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wind-hindcast-data
           path: ~/.cache/mhkit/wind-hindcast

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,8 +36,7 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          # TEMP: run all OSes for feat_add_python_3_13_support PR - remove after merge
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "develop" && "${{ github.head_ref }}" != "feat_add_python_3_13_support" ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "develop" ]]; then
             echo "matrix_os=[ \"ubuntu-latest\"]" >> $GITHUB_OUTPUT
           else
             echo "matrix_os=[\"windows-latest\", \"ubuntu-latest\", \"macos-latest\"]" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,8 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "develop" ]]; then
+          # TEMP: run all OSes for feat_add_python_3_13_support PR - remove after merge
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "develop" && "${{ github.head_ref }}" != "feat_add_python_3_13_support" ]]; then
             echo "matrix_os=[ \"ubuntu-latest\"]" >> $GITHUB_OUTPUT
           else
             echo "matrix_os=[\"windows-latest\", \"ubuntu-latest\", \"macos-latest\"]" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Py 3.10, 3.11, 3.12 | Windows Mac Linux
+name: Py 3.10, 3.11, 3.12, 3.13 | Windows Mac Linux
 
 on:
   pull_request:
@@ -207,7 +207,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{fromJson(needs.set-os.outputs.matrix_os)}}
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     env:
       PYTHON_VER: ${{ matrix.python-version }}
 
@@ -265,7 +265,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{fromJson(needs.set-os.outputs.matrix_os)}}
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}
@@ -335,7 +335,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{fromJson(needs.set-os.outputs.matrix_os)}}
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v6
@@ -460,7 +460,7 @@ jobs:
       matrix:
         module:
           [wave, tidal, river, dolfyn, power, loads, mooring, acoustics, utils]
-        python-version: ['3.12']
+        python-version: ['3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test-wheel-build.yml
+++ b/.github/workflows/test-wheel-build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See the [MHKiT documentation](https://mhkit-software.github.io/MHKiT) for more i
 
 ## Installation
 
-[MHKiT-Python](https://github.com/MHKiT-Software/MHKiT-Python) requires [Python (3.10-3.12)](https://www.python.org/).
+[MHKiT-Python](https://github.com/MHKiT-Software/MHKiT-Python) requires [Python (3.10-3.13)](https://www.python.org/).
 
 See [installation instructions](https://mhkit-software.github.io/MHKiT/installation.html) for more information.
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.10,<3.13
+  - python>=3.10,<3.14
   - pip
   - numpy>=2.0.0
   - pandas>=2.2.2


### PR DESCRIPTION
This PR verifies MHKiT-Python supports Python 3.13.

No python code changes were required.

README was updated to include Python 3.13

Actions were updated to include 3.13 in test matrices and for notebook tests (single version) 

Action versions for setup-miniconda and download-artifact were update