### PR TITLE
Dependency: Downgrade NLR-rex

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -527,6 +527,30 @@ jobs:
         run: |
           python -m pytest -c .github/workflows/pytest.ini mhkit/tests/${{ matrix.module }}/
 
+  windows-wheel-check:
+    # Verifies each mhkit extras group can be installed on Windows from prebuilt wheels alone,
+    # which is intented to mimic a user without windows MSVC compilers installed
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          [wave, tidal, river, dolfyn, power, loads, mooring, acoustics, utils, all]
+        python-version: ['3.13']
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Check ${{ matrix.module }} extra installs from wheels only on Windows
+        run: |
+          python -m pip install --upgrade pip
+          pip download --dest wheelhouse --only-binary=:all: --no-binary mhkit ".[${{ matrix.module }}]"
+
   notebook-matrix:
     runs-on: ubuntu-latest
     needs:

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -27,9 +27,4 @@ dependencies:
   - matplotlib>=3.9.1
   - fatpack
   - cartopy
-  # rex is installed from PyPI (NLR-rex), not conda-forge. The conda-forge
-  # `nrel-rex` is frozen at 0.2.84, which predates the s3:// fsspec support
-  # needed to read the wave hindcast .h5 files directly from S3. The [hsds] extra
-  # pulls the HSDS client dependencies the hindcast reads use.
-  - pip:
-      - NLR-rex[hsds]>=0.5.0
+  - NREL-rex

--- a/mhkit/__init__.py
+++ b/mhkit/__init__.py
@@ -11,7 +11,7 @@ from mhkit.warnings import configure_warnings
 
 configure_warnings()
 
-__version__ = "v1.1.1"
+__version__ = "v1.1.2"
 
 __copyright__ = """
 Copyright 2019, Alliance for Energy Innovation, LLC under the terms of 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ wave = [
     "scikit-learn>=1.5.1",
     "statsmodels>=0.14.2",
     "pytz",
-    "NLR-rex[hsds]>=0.5.0",
+    "NREL-rex",
     "beautifulsoup4",
     "bottleneck",
     "lxml",


### PR DESCRIPTION
On Windows, the installing mhkit 1.1.1 yields a failed instillation caused by the bitshuffle package as detailed in #461. The root cause appears to be the new `NLR-rex[hsds]` dependency in both pyproject.toml and environment-dev.yml

This reverts to an older version and removes the `hsds` extra which is not required.

Additionally `NLR-rex` is not available on conda-forge, while an older version of NREL-rex is available. An issue was submitted to NLR-rex: https://github.com/NatLabRockies/rex/issues/229, but our team does not have an eta on a conda-forge of NLR-rex.

This also adds tests for wheel builds on windows in an attempt to catch this build error during CI/CD.